### PR TITLE
ab-899: added default value of "." for trufflehog 

### DIFF
--- a/eze/plugins/tools/trufflehog.py
+++ b/eze/plugins/tools/trufflehog.py
@@ -48,6 +48,7 @@ Tips and Tricks
     EZE_CONFIG: dict = {
         "SOURCE": {
             "type": list,
+            "default": ".",
             "required": True,
             "help_text": """TruffleHog3 list of source folders to scan for secrets""",
         },

--- a/tests/__snapshots__/plugins_tools/trufflehog-help_text.txt
+++ b/tests/__snapshots__/plugins_tools/trufflehog-help_text.txt
@@ -7,6 +7,8 @@ config_help:
 [trufflehog]
 # SOURCE list
 # TruffleHog3 list of source folders to scan for secrets
+# default value: 
+#   SOURCE = "."
 # 
 SOURCE = ["..."]
 


### PR DESCRIPTION
- Added default source for trufflehog which is "."
- Changed tests\__snapshots__\plugins_tools\trufflehog-help_text.txt unit-testing to accompany changes made to the default source