### PR TITLE
BUG: bandit errors as objects not string

### DIFF
--- a/eze/core/tool.py
+++ b/eze/core/tool.py
@@ -22,7 +22,7 @@ from eze.utils.config import (
     extract_embedded_run_type,
 )
 from eze.utils.error import EzeError, EzeConfigError
-from eze.utils.log import log, log_debug, log_error, status_message
+from eze.utils.log import log, log_debug, log_error, status_message, clear_status_message
 
 
 class ScanResult:
@@ -338,7 +338,10 @@ Looks like {tool_name} is not installed
 ======================="""
         )
         tools = []
+        tools_counter = 0
+        tools_length = len(self.tools)
         for current_tool_name in self.tools:
+            tools_counter += 1
             current_tool_class = self.tools[current_tool_name]
             current_tool_type = current_tool_class.tool_type().name
             current_source_support = current_tool_class.source_support()
@@ -358,6 +361,7 @@ Looks like {tool_name} is not installed
             tool_entry["Type"] = current_tool_type
             tool_entry["Name"] = current_tool_name
             if include_version:
+                status_message(f"({tools_counter}/{tools_length}) obtaining '{current_tool_name}' tool version")
                 current_tool_version = current_tool_class.check_installed() or "Not Installed"
                 tool_entry["Version"] = current_tool_version
             tool_entry["License"] = current_tool_license
@@ -366,6 +370,7 @@ Looks like {tool_name} is not installed
             tool_entry["Description"] = current_tool_description
             tools.append(tool_entry)
 
+        clear_status_message()
         pretty_print_table(tools)
 
     def print_tools_help(self, tool_type: str = None, source_type: str = None, include_source_type: bool = None):

--- a/eze/plugins/tools/python_bandit.py
+++ b/eze/plugins/tools/python_bandit.py
@@ -1,4 +1,5 @@
 """Bandit Python tool class"""
+import json
 import shlex
 
 from eze.core.enums import VulnerabilityType, VulnerabilitySeverityEnum, ToolType, SourceType, Vulnerability
@@ -144,11 +145,12 @@ Warning: on production might want to set this to False to prevent found Secrets 
                 )
             )
 
+        errors = list(map(json.dumps, parsed_json["errors"]))
         report = ScanResult(
             {
                 "tool": self.TOOL_NAME,
                 "vulnerabilities": vulnerabilities_list,
-                "warnings": parsed_json["errors"],
+                "warnings": errors,
             }
         )
         return report

--- a/tests/__fixtures__/plugins_tools/raw-python-bandit-with-errors-report.json
+++ b/tests/__fixtures__/plugins_tools/raw-python-bandit-with-errors-report.json
@@ -1,0 +1,24 @@
+{
+  "errors": [
+    {
+      "filename": "ezefoo",
+      "reason": "No such file or directory"
+    }
+  ],
+  "generated_at": "2021-12-21T12:52:05Z",
+  "metrics": {
+    "_totals": {
+      "CONFIDENCE.HIGH": 0,
+      "CONFIDENCE.LOW": 0,
+      "CONFIDENCE.MEDIUM": 0,
+      "CONFIDENCE.UNDEFINED": 0,
+      "SEVERITY.HIGH": 0,
+      "SEVERITY.LOW": 0,
+      "SEVERITY.MEDIUM": 0,
+      "SEVERITY.UNDEFINED": 0,
+      "loc": 0,
+      "nosec": 0
+    }
+  },
+  "results": []
+}

--- a/tests/__snapshots__/plugins_tools/python-bandit-with-errors-output.json
+++ b/tests/__snapshots__/plugins_tools/python-bandit-with-errors-output.json
@@ -1,0 +1,11 @@
+{
+  "bom": null,
+  "fatal_errors": [],
+  "run_details": {},
+  "summary": {},
+  "tool": "python-bandit",
+  "vulnerabilities": [],
+  "warnings": [
+    "{\"filename\": \"ezefoo\", \"reason\": \"No such file or directory\"}"
+  ]
+}

--- a/tests/plugins/tools/test_python_bandit.py
+++ b/tests/plugins/tools/test_python_bandit.py
@@ -72,6 +72,17 @@ bandit source folder to scan for python files"""
         # Test container fixture and snapshot
         self.assert_parse_report_snapshot_test(snapshot, input_config)
 
+    def test_parse_report__error_case_snapshot(self, snapshot):
+        # Given
+        input_config = {"SOURCE": "src"}
+        # Test container fixture and snapshot
+        self.assert_parse_report_snapshot_test(
+            snapshot,
+            input_config,
+            "__fixtures__/plugins_tools/raw-python-bandit-with-errors-report.json",
+            "plugins_tools/python-bandit-with-errors-output.json",
+        )
+
     @mock.patch("eze.utils.cli.async_subprocess_run")
     @mock.patch("eze.utils.cli.is_windows_os", mock.MagicMock(return_value=True))
     @pytest.mark.asyncio


### PR DESCRIPTION
- added test case for python-bandit, 
- adding extra status messages to "eze tools list"
- and bug fix to jsonify all bandit errors

[AB#949](https://dev.azure.com/riversafe/0b0abc1f-f46a-4d96-a470-e1c546e3cf29/_workitems/edit/949)